### PR TITLE
Add rate limited mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ INCLUDE=-I. -I /usr/local/include/libbson-1.0 -I /usr/local/include/libmongoc-1.
 
 DEPS = launchargs.h
 OBJ = main.o 
-LIBS = -lmongoc-1.0 -lbson-1.0
+LIBS = -lmongoc-1.0 -lbson-1.0 -lm
 
 %.o: %.c $(DEPS)
 	$(CC) -c -o $@ $< $(INCLUDE) $(CFLAGS)


### PR DESCRIPTION
Hi John,

This adds a new -r option that will generate traffic to the database at the given number of operations per seconds (aggregated over all processes). The timings are generated using an exponential distribution to simulate independently arriving requests.